### PR TITLE
:update: /projects consumes /api/projects

### DIFF
--- a/components/CopyToClipboard.jsx
+++ b/components/CopyToClipboard.jsx
@@ -1,0 +1,25 @@
+import { Tooltip } from '@mui/material';
+import { useState } from 'react';
+
+const CopyToClipboard = (props) => {
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  const onCopy = (content) => {
+    navigator.clipboard.writeText(content);
+    setShowTooltip(true);
+  };
+
+  return (
+    <Tooltip
+      open={showTooltip}
+      title={'Link copied to clipboard!'}
+      leaveDelay={1500}
+      onClose={() => setShowTooltip(false)}
+      {...(props.TooltipProps || {})}
+    >
+      {props.children({ copy: onCopy })}
+    </Tooltip>
+  );
+};
+
+export default CopyToClipboard;


### PR DESCRIPTION
## ChangeList
- ```/projects``` consumes ```api/projects```, db changes will be reflected on projects page
- Adds progress loader for GET requests and redirects
- Telegram icon doesn't show if teamTelegramHandle is null
- Share project link and copy to clipboard
- BUGFIX for project_id mappings

## Further Work
- Add more social links and website link