### PR TITLE
Improved purchase UX

### DIFF
--- a/pages/purchase.jsx
+++ b/pages/purchase.jsx
@@ -146,8 +146,9 @@ const Purchase = () => {
     // when component is loaded initializing the conversion rate and counter
     useEffect(() => {
         updateConversionRate();
-        const now = new Date().valueOf();
         // update counter every 1 second or 1000ms
+        const now = new Date().valueOf();
+        clearInterval(interval);
         setStateInterval(setInterval(() => updateWaitCounter(now), 1000));
     }, [])
 
@@ -432,8 +433,8 @@ const Purchase = () => {
                     sigusd: (formData.currency === 'sigusd') ? formData.amount : 0.0
                 })
                 
-                clearInterval(interval);
                 const now = new Date().valueOf();
+                clearInterval(interval);
                 setStateInterval(setInterval(() => updateWaitCounter(now, 1000)));
 
                 checkWalletApproval(false)

--- a/pages/purchase.jsx
+++ b/pages/purchase.jsx
@@ -66,6 +66,9 @@ const defaultOptions = {
     },
 };
 
+// wait time in mins
+const WAIT_TIME = 5;
+
 const Purchase = () => {
     const mediumWidthUp = useMediaQuery((theme) => theme.breakpoints.up('md'));
     // boolean object for each checkbox
@@ -132,9 +135,9 @@ const Purchase = () => {
     // calculate and update the timer string
     const updateWaitCounter = (lastSubmit) => {
         const now = new Date().valueOf();
-        const diff = lastSubmit - now + 5 * 60 * 1000;
-        const mm = Math.floor(diff / (60 * 1000)).toString(10);
-        const ss = (Math.floor(diff / (1000)) % 60).toString(10);
+        const diff = lastSubmit - now + WAIT_TIME * 60 * 1000;
+        const mm = Math.max(0, Math.floor(diff / (60 * 1000))).toString(10);
+        const ss = Math.max(0, (Math.floor(diff / (1000)) % 60)).toString(10);
         const pmm = mm.length === 2 ? mm : ('0'+mm);
         const pss = ss.length === 2 ? ss : ('0'+ss);
         setTimer(`${pmm}:${pss}`);
@@ -188,7 +191,7 @@ const Purchase = () => {
         // show the conversion rate if currency is erg
         const additionalMsg =
           formData.currency === 'erg'
-            ? ' For erg current conversion rate is ' + conversionRate + '.'
+            ? ' For erg current conversion rate is ' + conversionRate + '$.'
             : '';
         setSigusdApprovalMessage(
           'This address is approved for ' +
@@ -383,7 +386,7 @@ const Purchase = () => {
             });
             updateFormData({
               ...formData,
-              amount: amount,
+              amount: e.target.value,
             });
           } else {
             setSigHelper('Must be a value within your approved amount');
@@ -393,7 +396,7 @@ const Purchase = () => {
             });
             updateFormData({
                 ...formData,
-                amount: amount,
+                amount: e.target.value,
               });
           }
         }
@@ -670,7 +673,7 @@ const Purchase = () => {
                                     navigator.clipboard.writeText(successMessageData.ergs)
                                     copyToClipboard(successMessageData.ergs)
                                 }
-                            } variant="span" sx={{ color: 'text.primary' }}>
+                            } variant="span" sx={{ color: 'text.primary', cursor: 'pointer' }}>
                                 {successMessageData.ergs} Erg
                             </Typography>
                             {(successMessageData.sigusd > 0.0) && 
@@ -678,7 +681,7 @@ const Purchase = () => {
                                 navigator.clipboard.writeText(successMessageData.sigusd)
                                 copyToClipboard(successMessageData.sigusd)
                             }
-                            } variant="span" sx={{ color: 'text.primary' }}>
+                            } variant="span" sx={{ color: 'text.primary', cursor: 'pointer' }}>
                                  {successMessageData.sigusd} sigUSD
                             </Typography></>}
                             {' '}to{' '}
@@ -686,7 +689,7 @@ const Purchase = () => {
                                     navigator.clipboard.writeText(successMessageData.address)
                                     copyToClipboard(successMessageData.address)
                                 }
-                            } variant="span" sx={{ color: 'text.primary' }}>
+                            } variant="span" sx={{ color: 'text.primary', cursor: 'pointer' }}>
                                 {friendlyAddress(successMessageData.address)}
                             </Typography>
                             {(successMessageData.sigusd > 0.0) && 


### PR DESCRIPTION
# Improved Purchase UX
- ## Add the ability to enter erg amount instead of just sigUSD and show conversion rate. 
![image](https://user-images.githubusercontent.com/42897033/149629584-9471d862-f436-455a-8e1d-1d6c1693c051.png)

- ## Timer to estimate wait time (10 mins)
![image](https://user-images.githubusercontent.com/42897033/149650040-0dc0e5a6-701f-406f-92f6-8f766b8250bd.png)

- ## Reopen Modal if closed (only shown after modal is closed)
![image](https://user-images.githubusercontent.com/42897033/149628135-2d71d1af-1f9b-4ddc-9f1d-259364d5bcb6.png)

- cursor: pointer for copyToClipboard text in the modal

## Todo:
- [x] Linear Progress
- [x] Wait time is 10 mins (Remove check button)

## Further Work: 
- change to new API ```/api/vesting/vest```
- change hardcoded timestamp