### PR TITLE
Truncating fractional digits and using correct locale characters

### DIFF
--- a/components/dashboard/StakingTable.jsx
+++ b/components/dashboard/StakingTable.jsx
@@ -112,7 +112,7 @@ const StakingTable = ({ data }) => {
     <>
       <Box>
         <Typography variant="h5" color="text.primary" sx={{ mb: 1, pl: 1 }}>
-          Total Staked Tokens: {stakeObject.totalStaked}
+          Total Staked Tokens: {stakeObject.totalStaked?.toLocaleString(navigator.language, { maximumFractionDigits: 2 })}
         </Typography>
         <Typography
           variant="p"
@@ -150,7 +150,7 @@ const StakingTable = ({ data }) => {
               color="text.secondary"
               sx={{ textTransform: 'capitalize', fontWeight: '400' }}
             >
-              {stakeObject.addresses[address].totalStaked}
+              {stakeObject.addresses[address].totalStaked?.toLocaleString(navigator.language, { maximumFractionDigits: 2 })}
             </Typography>
           </Typography>
           {checkSmall ? (

--- a/components/staking/StakingRewardsBox.jsx
+++ b/components/staking/StakingRewardsBox.jsx
@@ -38,7 +38,7 @@ const StakingRewardsBox = (props) => {
             {props.loading ? (
               <CircularProgress sx={{ mt: 2, color: '#fff' }} />
             ) : props.totalStaked ? (
-              props.totalStaked
+              props.totalStaked?.toLocaleString(navigator.language, { maximumFractionDigits: 2 })
             ) : (
               '-'
             )}

--- a/components/staking/UnstakingTable.jsx
+++ b/components/staking/UnstakingTable.jsx
@@ -117,7 +117,7 @@ const UnstakingTable = ({ data, unstake }) => {
     <>
       <Box>
         <Typography variant="h6" color="text.primary" sx={{ mb: 1, pl: 1 }}>
-          Total Staked Tokens: {stakeObject.totalStaked}
+          Total Staked Tokens: {stakeObject.totalStaked?.toLocaleString(navigator.language, { maximumFractionDigits: 2 })}
         </Typography>
         <Typography
           variant="p"
@@ -155,7 +155,7 @@ const UnstakingTable = ({ data, unstake }) => {
               color="text.secondary"
               sx={{ textTransform: 'capitalize', fontWeight: '400' }}
             >
-              {stakeObject.addresses[address].totalStaked}
+              {stakeObject.addresses[address].totalStaked?.toLocaleString(navigator.language, { maximumFractionDigits: 2 })}
             </Typography>
           </Typography>
           <Table sx={{ p: 0 }}>


### PR DESCRIPTION
Making browser language respected to use `.` or `,` for decimal digits in total staked, and truncating to 2 digits past decimal since ErgoPad has 2 decimals in its token description.